### PR TITLE
Update TourItems.xml

### DIFF
--- a/1.1.4.4/DW2/TourItems.xml
+++ b/1.1.4.4/DW2/TourItems.xml
@@ -1105,7 +1105,7 @@ Wenn Sie einmal mit der linken Maustaste auf ein Werft-Symbol klicken, wird der 
   </TourItem>
 
   <TourItem>
-    <Title>Schiffsdesign Bildschirm</Title>
+    <Title>Ship Design Screen</Title>
     <Steps>
       <TourStep>
         <StepTitle>Einführung</StepTitle>
@@ -1419,7 +1419,7 @@ Ganz unten in der Detailanzeige finden Sie eine Liste aller Events, an denen der
   </TourItem>
 
   <TourItem>
-    <Title>Forschungsfenster</Title>
+    <Title>Research Screen</Title>
     <Steps>
       <TourStep>
         <StepTitle>Übersicht</StepTitle>


### PR DESCRIPTION
SO muss es sein:

Sorry für die Diskrepanzen.

Ich habe den Text bei 
<TourItem>
<Title>Schiffsdesign Bildschirm</Title>
auf
    <Title>Ship Design Screen</Title>
geändert sowie bei 

<TourItem>Forschungsfenster</Title>

auf

<Title>Research Screen</Title>

geändert.
Es sind so nur diese beiden Bezeichnungen wichtig.

BITTE AUCH BEI 1.1.2.4 so rüberschieben, da sind auch noch nicht alle Korrekturen von 1.1.4.4 eingeflossen.