### PR TITLE
Baustapel

### DIFF
--- a/1.2.0.4 Beta/DW2/GameText.txt
+++ b/1.2.0.4 Beta/DW2/GameText.txt
@@ -214,7 +214,7 @@ Range		;Reichweite
 Avg DPS		;mttl. DPS
 Min DPS		;Min. DPS
 Fighters		;Jäger
-Building		;Gebäude
+Building		;Baustapel
 waiting		;warte
 Docked		;Angedockt
 Awaiting Construction		;Warte auf Konstruktion


### PR DESCRIPTION
![baustapel](https://github.com/Marty651/DW2-Deutsch/assets/134811233/72414e01-e9a2-4d8e-a25d-08f4a31b0b3a)
Gebäude passt nicht.
Automatische Übersetzung hat ihre Grenzen.
Ich finde Baustapel passt ganz gut.